### PR TITLE
Fixes ```--enable-bitcoin``` flag support with ```bash```

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dfinity"
   ],
   "scripts": {
-    "dfx:start": "sh ./scripts/start.sh",
+    "dfx:start": "bash ./scripts/start.sh",
     "dfx:install": "yarn dfx:identity && sh ./scripts/install.sh",
     "dfx:identity": "dfx deps deploy internet-identity",
     "dfx:stop": "dfx stop",

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,5 +1,8 @@
+#!/bin/bash
 if [[ $* == *--enable-bitcoin* ]]; then
+    echo "Starting DFX with Bitcoin"
     dfx start --enable-bitcoin --clean
 else
+    echo "Starting DFX without Bitcoin"
     dfx start --clean
 fi


### PR DESCRIPTION
fixes:
```bash
./scripts/start.sh: 1: [[: not found
```
in
```bash
$ yarn dfx:start --enable-bitcoin
yarn run v1.22.19
$ sh ./scripts/start.sh --enable-bitcoin
./scripts/start.sh: 1: [[: not found
Running dfx start for version 0.15.0
Using the default definition for the 'local' shared network because ~/.config/dfx/networks.json does not exist.
Initialized replica.
Dashboard: http://localhost:37947/_/dashboard
```
and detects ```--enable-bitcoin``` flag.